### PR TITLE
Add built file to /Users/travis.smith/Projects/GO/bin on build

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ If you want to compile it from source, you will need Go 1.7 or later, and the [G
   `glide install`
 4. Compile the binary:  
   - Linux/macOS/*nix: `go install -o $GOPATH/bin/akamai .``
-  - Windows `go build -o $GOPATH/bin/akamai.exe`
+  - Windows `go build -o %GOPATH%/bin/akamai.exe`
 
 ### Credentials
 

--- a/README.md
+++ b/README.md
@@ -76,7 +76,6 @@ If you want to compile it from source, you will need Go 1.7 or later, and the [G
 4. Compile the binary:  
   - Linux/macOS/*nix: `go install -o $GOPATH/bin/akamai .``
   - Windows `go build -o $GOPATH/bin/akamai.exe`
-5. Move the binary (`akamai` or `akamai.exe`) it to your `PATH`
 
 ### Credentials
 

--- a/README.md
+++ b/README.md
@@ -74,8 +74,8 @@ If you want to compile it from source, you will need Go 1.7 or later, and the [G
 3. Install dependencies using Glide:  
   `glide install`
 4. Compile the binary:  
-  - Linux/macOS/*nix: `go build -o akamai`
-  - Windows `go build -o akamai.exe`
+  - Linux/macOS/*nix: `go install -o $GOPATH/bin/akamai .``
+  - Windows `go build -o $GOPATH/bin/akamai.exe`
 5. Move the binary (`akamai` or `akamai.exe`) it to your `PATH`
 
 ### Credentials

--- a/README.md
+++ b/README.md
@@ -74,8 +74,10 @@ If you want to compile it from source, you will need Go 1.7 or later, and the [G
 3. Install dependencies using Glide:  
   `glide install`
 4. Compile the binary:  
-  - Linux/macOS/*nix: `go install -o $GOPATH/bin/akamai .``
-  - Windows `go build -o %GOPATH%/bin/akamai.exe`
+  - Linux/macOS/*nix:  
+  `go build -o $GOPATH/bin/akamai .`
+  - Windows  
+  `go build -o %GOPATH%/bin/akamai.exe`
 
 ### Credentials
 


### PR DESCRIPTION
`go build` allows you to control the output. Why not put the output in the `$GOPATH/bin` folder which will be in a user's PATH (if they have installed GO correctly)?