### PR TITLE
Fix Python extension import failures (issue #33)

### DIFF
--- a/akamai.go
+++ b/akamai.go
@@ -289,9 +289,9 @@ func cmdSubcommand(c *cli.Context) error {
 
 	var packageDir string
 	if len(executable) == 1 {
-		packageDir = findPackageDir(executable[0])
+		packageDir = findPackageDir(filepath.Dir(executable[0]))
 	} else if len(executable) > 1 {
-		packageDir = findPackageDir(executable[1])
+		packageDir = findPackageDir(filepath.Dir(executable[1]))
 	}
 
 	cmdPackage, _ := readPackage(packageDir)
@@ -1193,7 +1193,7 @@ func setPythonPath(packageDir string) error {
 	}
 
 	if len(pythonPaths) > 0 {
-		pythonPath = pythonPaths[0]
+		pythonPath = pythonPaths[0] + string(os.PathSeparator) + "site-packages"
 	}
 
 	systemPythonPath := os.Getenv("PYTHONPATH")


### PR DESCRIPTION
Python extensions attempting to import packages from their `.local`
directory failed due to the following issues:
1. `/site-packages` suffix missing from `$PYTHONPATH`.
2. Extension language not identified as Python due to an error in the
 `package.json`-locating logic.