### PR TITLE
Docker: Remove VOLUME for .edgerc

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,6 @@ RUN echo "[cli]" > /cli/.akamai-cli/config && \
     echo "last-upgrade-check    = ignore" >> /cli/.akamai-cli/config
 
 ENV AKAMAI_CLI_HOME=/cli
-VOLUME /root/.edgerc
 VOLUME /cli
 ENTRYPOINT ["/usr/local/bin/akamai"]
 CMD ["--daemon"]


### PR DESCRIPTION
https://docs.docker.com/engine/reference/builder/#volume
You don't need to specify `VOLUME`s. With the `VOLUME` directive if no mount is specified at runtime, it is made a directory.
As it is a mount point, the directory cannot be deleted from within the container. this makes configuring .edgerc from within the container unnecessarily hard.