### PR TITLE
set WORKDIR to something that can have a volume map created for it

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,5 +45,7 @@ RUN echo "[cli]" > /cli/.akamai-cli/config && \
 ENV AKAMAI_CLI_HOME=/cli
 VOLUME /root/.edgerc
 VOLUME /cli
+RUN test -d /data || mkdir /data
+WORKDIR /data
 ENTRYPOINT ["/usr/local/bin/akamai"]
 CMD ["--daemon"]


### PR DESCRIPTION
This is so that commands like 'akamai property-manager import' and
'akamai property-manager update-local' can output the config to
a local client location for committing into a git repo.