### PR TITLE
allow npm to execute scripts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,7 @@ RUN mkdir /cli && \
     apk add --no-cache git python2 python2-dev py2-pip python3 python3-dev wget jq openssl openssl-dev curl nodejs build-base libffi libffi-dev go npm && \
     pip2 install --upgrade pip && \
     pip3 install --upgrade pip && \
+    npm config set unsafe-perm true && \
     mkdir -p $GOBIN && \
     curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh; \
     if [[ $SOURCE_BRANCH == "master" ]]; then \


### PR DESCRIPTION
This is to fix problems with npm, because docker here executes everything as root there is an issue with npm executing scripts from package.json.

Since npm 5 all scripts defined in package.json won't be executed automatically (e.g. a postinstall script) if the user executing npm command is root (see https://github.com/npm/npm/issues/17346).

This is problematic for us in  cli-sandbox (https://github.com/akamai/cli-sandbox/issues/38) because we need to perform certain build steps after `npm install` is executed from the akamai-cli.

Without those steps users are getting errors and can't run any cli-sandbox commands.

Solution is to allow npm to execute scripts even if run as root (this should be safe because it is only for docker).