### PR TITLE
Fix formatting of welcome message

### DIFF
--- a/pkg/stats/stats.go
+++ b/pkg/stats/stats.go
@@ -66,7 +66,7 @@ func FirstRunCheckStats(ctx context.Context, bannerShown bool) bool {
 	term.Writeln(shareDataMsg)
 	logger.Debug(shareDataMsg)
 	shareDataMsg = fmt.Sprintf("Note: if you choose to opt-out, a single %s event will be submitted to help track overall usage.\n", anonymous)
-	term.Writeln("Note: if you choose to opt-out, a single %s event will be submitted to help track overall usage.\n", anonymous)
+	term.Sprintf("Note: if you choose to opt-out, a single %s event will be submitted to help track overall usage.\n", anonymous)
 	logger.Debug(shareDataMsg)
 
 	shareDataMsg = fmt.Sprintf("Send %s diagnostics and usage data to Akamai? [Y/n]: ", anonymous)


### PR DESCRIPTION
In the welcome message, note about opt-out is not correctly formatted (**anonymous** is on a newline instead of being replaced in the sentence).
```

                Welcome to Akamai CLI v1.3.0


Help Akamai improve Akamai CLI by automatically sending anonymous diagnostics and usage data.
Examples of data being sent include upgrade statistics, and packages installed and updated.
Note: if you choose to opt-out, a single %s event will be submitted to help track overall usage.
 anonymous
? Send anonymous diagnostics and usage data to Akamai? [Y/n]:  (Y/n)
```