### PR TITLE
Issue 188 local docker dev for make

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+# The purpose of this file is to simply run make commands in deterministic
+# environment for those interested in contributing. This is not to be used
+# for production purposes.
+FROM ubuntu:22.04
+
+RUN apt update && apt upgrade
+
+RUN apt install -y wget make vim git curl golang-go
+
+# This is a workaround so that running `make lint` does not result in a 
+# "error obtaining VCS status: exit status 128" error
+RUN go env -w GOFLAGS="-buildvcs=false"

--- a/Makefile
+++ b/Makefile
@@ -95,6 +95,17 @@ clean: ; $(info $(M) Removing 'bin' directory and test results...) @ ## Cleanup 
 clean-tools: ## Cleanup installed packages
 	@rm -rf $(BIN)/go*
 
+.PHONY: dockerized
+dockerized: ; $(info $(M) Running `make $(target)` in docker...) @
+	@echo "$(target)"
+	@if [ "$(target)" = "dockerized"]; then \
+		echo "Please do not hurt yourself.";\
+		exit 1;\
+	fi
+	@docker build -t local/akamai-cli-build .
+	@docker run --rm -v $(CURDIR):/go/src/github.com/akamai/cli -w /go/src/github.com/akamai/cli local/akamai-cli-build \
+		make "$(target)"
+
 .PHONY: help
 help: ## List all make targets
 	echo $(MAKEFILE_LIST)

--- a/README.md
+++ b/README.md
@@ -130,6 +130,28 @@ To compile Akamai CLI from source:
 
 5. Move the `akamai` or `akamai.exe` binary so that it's available in your `$PATH`.
 
+### Contributing to Akamai's CLI
+
+**Prerequisite:** You must have `docker` installed.
+
+To ensure consistency in how this project builds, use this [Dockerfile](./Dockerfile). 
+
+1. Write your code, and include tests.
+
+1. Verify linting passes
+    ```sh
+    $ make dockerized target=lint
+    ```
+1. Verify your tests pass
+    ```sh
+    $ make dockerized target=test
+    ```
+1. Ensure that the project builds in its entirety.
+    ```sh
+    $ make dockerized target=all
+    ```
+1. Submit your PR
+
 ### API credentials
 
 Akamai-branded packages use a `.edgerc` file for standard EdgeGrid authentication. By default, CLI looks for credentials in your `$HOME` directory.


### PR DESCRIPTION
This pull request includes a `Dockerfile`, which is intended to be used only for development purposes. This also contains a `make` target that allows a user to run any of the `make` commands inside of a consistent operating system. This will allow other developers to contribute and build against a similar environment.